### PR TITLE
Add simple supervisor structure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,12 @@ tracing = {version = "0.1.41"}
 tracing = {version = "0.1.41"}
 tracing-subscriber = { version="0.3.0"}
 glommio = { version = "0.9.0", git="https://github.com/nand-nor/glommio", rev="b30f9eb783301b19b934ca203eb9c32ecf882ee6"}
+flume = {version= "0.11.1", features=["async"]}
 
 [[example]]
 name = "simple"
+required-features=["glommio"]
+
+[[example]]
+name = "supervised_simple"
 required-features=["glommio"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # glommactor
-An simple actor framework for the glommio runtime (for learning purposes only)
+An simple actor framework for the glommio runtime (for learning purposes only)! And someday
+maybe other runtimes if the design allows for it.
+
+Heavily inspired by [act-zero](https://www.github.com/Diggsey/act-zero) and Alice Ryhl's
+[tokio actors](https://ryhl.io/blog/actors-with-tokio/). 

--- a/examples/supervised_simple/main.rs
+++ b/examples/supervised_simple/main.rs
@@ -1,0 +1,320 @@
+use glommactor::{
+    handle::SupervisedActorHandle, Actor, ActorError, ActorId, ActorState, Event, SupervisedActor,
+    SupervisorHandle, SupervisorMessage,
+};
+use glommio::{executor, Latency, LocalExecutorBuilder, Placement, Shares};
+use std::time::Duration;
+use tracing::Level;
+use tracing_subscriber::FmtSubscriber;
+
+pub type Reply = flume::Sender<()>;
+
+#[derive(Clone, Debug)]
+pub enum HelloWorldEvent {
+    SayHello { reply: Reply },
+}
+
+impl Event for HelloWorldEvent {}
+
+struct HelloWorldActor {
+    receiver: flume::Receiver<HelloWorldEvent>,
+    supervisor: flume::Receiver<SupervisorMessage>,
+    state: ActorState,
+    id: ActorId,
+}
+
+impl HelloWorldActor {
+    fn new(
+        receiver: flume::Receiver<HelloWorldEvent>,
+        supervisor: flume::Receiver<SupervisorMessage>,
+    ) -> Self {
+        Self {
+            receiver,
+            supervisor,
+            state: ActorState::Started,
+            id: 0,
+        }
+    }
+}
+
+struct HandleWrapper {
+    handle: SupervisedActorHandle<HelloWorldEvent>,
+}
+
+impl Clone for HandleWrapper {
+    fn clone(&self) -> Self {
+        Self {
+            handle: self.handle.clone(),
+        }
+    }
+}
+
+impl HandleWrapper {
+    async fn say_hello(&self) -> Result<(), ActorError<HelloWorldEvent>> {
+        let (tx, rx) = flume::bounded(1);
+        let msg = HelloWorldEvent::SayHello { reply: tx };
+        self.handle.send(msg).await.ok();
+
+        rx.recv_async().await.map_err(|e| {
+            let msg = format!("Send cancelled {e:}");
+            tracing::error!(msg);
+            ActorError::ActorError(msg)
+        })?;
+
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl Actor<HelloWorldEvent> for HelloWorldActor
+where
+    HelloWorldEvent: Event + Send,
+{
+    type Rx = futures::channel::mpsc::Receiver<HelloWorldEvent>;
+    type Error = ActorError<HelloWorldEvent>;
+    type Result = Result<(), Self::Error>;
+    async fn run(self) -> Self::Result {
+        self.event_loop().await
+    }
+}
+
+#[async_trait::async_trait]
+impl SupervisedActor<HelloWorldEvent> for HelloWorldActor where HelloWorldEvent: Event + Send {}
+
+impl HelloWorldActor {
+    async fn say_hello(&mut self) {
+        tracing::info!("Hello, world!");
+    }
+
+    async fn set_id(&mut self, id: ActorId) {
+        self.id = id;
+    }
+
+    async fn event_loop(mut self) -> Result<(), ActorError<HelloWorldEvent>> {
+        self.state = ActorState::Running;
+        loop {
+            futures::select! {
+                    event = self.receiver.recv_async() => {
+                    match event {
+                        Ok(event) => self.process_event(event).await,
+                        Err(e) => {
+                            tracing::warn!("Channel error {e:}");
+                            self.state = ActorState::Stopping;
+                        }
+                    };
+                },
+                event = self.supervisor.recv_async() => {
+                    match event {
+                        Ok(event) => self.process_supervision(event).await,
+                        Err(e) => {
+                            tracing::warn!("Supervisor channel error {e:}");
+                            self.state = ActorState::Stopping;
+                        }
+                    };
+                }
+            };
+
+            if self.state == ActorState::Stopping {
+                break;
+            }
+        }
+        tracing::info!("Actor has shut down");
+        self.state = ActorState::Stopped;
+        Ok(())
+    }
+
+    async fn process_supervision(&mut self, msg: SupervisorMessage) {
+        tracing::trace!("Processing supervision {msg:?}");
+
+        match msg {
+            SupervisorMessage::SetId { id } => {
+                self.set_id(id).await;
+            }
+            SupervisorMessage::Start => {
+                self.state = ActorState::Running;
+            }
+            SupervisorMessage::Stop => {
+                self.state = ActorState::Stopped;
+            }
+            SupervisorMessage::ClearAll => todo!(),
+            SupervisorMessage::Shutdown => {
+                tracing::info!("Shutting down!");
+                self.state = ActorState::Stopping;
+                // re-assigning the receiver will close all sender ends
+                let (_sender, receiver) = flume::unbounded();
+                self.receiver = receiver;
+            }
+            SupervisorMessage::Backup => todo!(),
+            SupervisorMessage::Id { reply } => {
+                reply.send(self.id).ok();
+            }
+            SupervisorMessage::State { reply } => {
+                reply.send(self.state.clone()).ok();
+            }
+        }
+    }
+
+    async fn process_event(&mut self, event: HelloWorldEvent) {
+        tracing::trace!("Processing event {event:?}");
+
+        match event {
+            HelloWorldEvent::SayHello { reply } => {
+                if self.state == ActorState::Stopped {
+                    drop(reply);
+                    return;
+                }
+                reply.send(self.say_hello().await).ok();
+            }
+        }
+    }
+}
+
+fn main() -> Result<(), ActorError<HelloWorldEvent>> {
+    let subscriber = FmtSubscriber::builder()
+        .with_max_level(Level::TRACE)
+        .finish();
+
+    tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
+
+    let mut handle_vec = vec![];
+
+    // create supervisor
+    let (mut supervisor, supervisor_handle) = SupervisorHandle::new();
+
+    // direct access via actor
+    let (tx, rx, id) = supervisor.new_supervisee_setup().unwrap();
+
+    // create a supervised actor and handle before running in local executor tasks
+    let (actor, handle) = SupervisedActorHandle::new(tx, rx, id, HelloWorldActor::new);
+
+    // let supervised_handle = handle.clone();
+    let handle_wrapper = HandleWrapper { handle };
+
+    // pin actor to core 0
+    handle_vec.push(
+        LocalExecutorBuilder::new(Placement::Fixed(0))
+            .name(&format!("{}{}", "rt-actor", 0))
+            .spawn(move || async move {
+                let tq = executor().create_task_queue(
+                    Shares::default(),
+                    Latency::Matters(Duration::from_millis(500)),
+                    "actor-tq",
+                );
+
+                let task = glommio::spawn_local_into(actor.run(), tq)
+                    .map(|t| t.detach())
+                    .map_err(|e| {
+                        tracing::error!("Error spawning actor {e:}");
+                        panic!("Actor core panic");
+                    })
+                    .ok();
+                if let Some(task) = task {
+                    task.await;
+                }
+            })
+            .unwrap(),
+    );
+
+    // pin handle to actor to core 1
+    handle_vec.push(
+        LocalExecutorBuilder::new(Placement::Fixed(1))
+            .name(&format!("{}{}", "rt-handle", 0))
+            .spawn(move || async move {
+                let tq = executor().create_task_queue(
+                    Shares::default(),
+                    Latency::NotImportant,
+                    "handle-tq",
+                );
+                let fut = async move {
+                    if let Err(e) = handle_wrapper.say_hello().await {
+                        tracing::error!("Failed to send say hello {e:}");
+                    } else {
+                        tracing::info!("Sent say hello request");
+                    }
+                };
+
+                let task = glommio::spawn_local_into(fut, tq)
+                    .map(|t| t.detach())
+                    .map_err(|e| {
+                        tracing::error!("Error spawning task for handle {e:}");
+                        panic!("handle core panic");
+                    })
+                    .ok();
+                if let Some(task) = task {
+                    task.await;
+                }
+            })
+            .unwrap(),
+    );
+
+    // pin supervisor to core 2
+    handle_vec.push(
+        LocalExecutorBuilder::new(Placement::Fixed(2))
+            .name(&format!("{}{}", "rt-supervisor", 0))
+            .spawn(move || async move {
+                let tq = executor().create_task_queue(
+                    Shares::default(),
+                    Latency::Matters(Duration::from_millis(1)),
+                    "supervisor-tq",
+                );
+
+                // create separate task queue for spawning supervisor actor
+                let stq = executor().create_task_queue(
+                    Shares::default(),
+                    Latency::Matters(Duration::from_millis(1)),
+                    "supervisor-tq-run",
+                );
+                glommio::spawn_local_into(supervisor.run(), stq)
+                    .map(|t| t.detach())
+                    .map_err(|e| {
+                        tracing::error!("Error spawning task for handle {e:}");
+                        panic!("handle core panic");
+                    })
+                    .ok();
+
+                let fut = async move {
+                    let state = supervisor_handle
+                        .actor_state(id)
+                        .await
+                        .map_err(|e| {
+                            tracing::error!("Failed to send shutdown actor action {e:}");
+                        })
+                        .ok();
+
+                    if let Some(state) = state {
+                        tracing::info!("Actor state for id {id:} is {state:?}");
+                    }
+
+                    // sleep so handle can interact with actor a bit
+                    // before sending shutdown
+                    glommio::timer::sleep(Duration::from_secs(2)).await;
+                    tracing::info!("Supervisor sending shutdown request");
+                    supervisor_handle
+                        .shutdown_actor(id)
+                        .await
+                        .map_err(|e| {
+                            tracing::error!("Failed to send shutdown actor action {e:}");
+                        })
+                        .ok();
+                };
+
+                let task = glommio::spawn_local_into(fut, tq)
+                    .map(|t| t.detach())
+                    .map_err(|e| {
+                        tracing::error!("Error spawning task for handle {e:}");
+                        panic!("handle core panic");
+                    })
+                    .ok();
+                if let Some(task) = task {
+                    task.await;
+                }
+            })
+            .unwrap(),
+    );
+
+    for handle in handle_vec {
+        handle.join().unwrap();
+    }
+
+    Ok(())
+}

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -6,7 +6,7 @@ pub trait Actor<T: Event + Send>: Sized + Unpin + 'static {
     async fn run(self) -> Self::Result;
 }
 
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq, Debug)]
 pub enum ActorState {
     Stopped,
     Started,
@@ -16,3 +16,6 @@ pub enum ActorState {
 
 // marker trait
 pub trait Event {}
+
+#[async_trait::async_trait]
+pub trait SupervisedActor<T: Event + Send>: Actor<T> {}

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,6 +16,9 @@ pub enum ActorError<T> {
     #[error("Channel closed, no messages left to process")]
     ChannelClosed,
 
+    #[error("System error {0}")]
+    SystemError(String),
+
     #[error("Unknown")]
     Unknown,
 }
@@ -27,6 +30,7 @@ impl<T> Debug for ActorError<T> {
             Self::SendError(arg0) => f.debug_tuple("SendError").field(arg0).finish(),
             Self::IoError(arg0) => f.debug_tuple("IoError").field(arg0).finish(),
             Self::ChannelClosed => write!(f, "ChannelClosed"),
+            Self::SystemError(arg0) => f.debug_tuple("SystemError").field(arg0).finish(),
             Self::Unknown => write!(f, "Unknown"),
         }
     }

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -1,4 +1,10 @@
-use super::{Actor, ActorError, Event};
+use crate::ActorState;
+
+use super::{Actor, ActorError, ActorId, Event, SupervisorMessage};
+
+pub trait Handle {}
+
+impl<T: Event + Send> Handle for ActorHandle<T> {}
 
 #[derive(Clone)]
 pub struct ActorHandle<T: Event + Send> {
@@ -19,6 +25,111 @@ impl<T: Event + Send> ActorHandle<T> {
         tracing::trace!("Sending event from handle to actor");
         self.sender
             .send_async(event)
+            .await
+            .map_err(ActorError::from)
+    }
+}
+
+pub struct SupervisedActorHandle<T: Event + Send> {
+    sender: flume::Sender<T>,
+    broadcast: flume::Sender<SupervisorMessage>,
+    id: ActorId,
+}
+
+impl<T: Event + Send> Clone for SupervisedActorHandle<T> {
+    fn clone(&self) -> Self {
+        Self {
+            sender: self.sender.clone(),
+            broadcast: self.broadcast.clone(),
+            id: self.id,
+        }
+    }
+}
+
+impl<T: Event + Send> Handle for SupervisedActorHandle<T> {}
+
+#[async_trait::async_trait]
+pub trait SupervisedHandle: Handle {
+    type Rx;
+    type Error;
+    async fn send_shutdown(&self) -> Result<(), Self::Error>;
+    async fn send_start(&self) -> Result<(), Self::Error>;
+    async fn subscribe_direct(&self) -> Self::Rx;
+    async fn actor_state(&self) -> Result<ActorState, Self::Error>;
+}
+
+#[async_trait::async_trait]
+impl<T: Event + Send> SupervisedHandle for SupervisedActorHandle<T> {
+    type Rx = flume::Sender<T>;
+    type Error = ActorError<SupervisorMessage>;
+    async fn send_shutdown(&self) -> Result<(), Self::Error> {
+        self.supervisor_send(SupervisorMessage::Shutdown).await
+    }
+    async fn send_start(&self) -> Result<(), Self::Error> {
+        self.supervisor_send(SupervisorMessage::Start).await
+    }
+    async fn subscribe_direct(&self) -> Self::Rx {
+        self.handle_subscribe_direct().await
+    }
+    async fn actor_state(&self) -> Result<ActorState, Self::Error> {
+        self.get_state().await
+    }
+}
+
+impl<T: Event + Send> SupervisedActorHandle<T> {
+    pub fn new<A: Actor<T>>(
+        broadcast: flume::Sender<SupervisorMessage>,
+        bcast_rx: flume::Receiver<SupervisorMessage>,
+        id: ActorId,
+        constructor: impl FnOnce(flume::Receiver<T>, flume::Receiver<SupervisorMessage>) -> A,
+    ) -> (A, Self) {
+        let (sender, receiver) = flume::unbounded();
+        let actor = constructor(receiver, bcast_rx);
+        (
+            actor,
+            Self {
+                id,
+                sender,
+                broadcast,
+            },
+        )
+    }
+
+    pub async fn handle_subscribe_direct(&self) -> flume::Sender<T> {
+        self.sender.clone()
+    }
+
+    pub async fn handle_subscribe_bcast(&self) -> flume::Sender<SupervisorMessage> {
+        self.broadcast.clone()
+    }
+
+    pub async fn get_state(&self) -> Result<ActorState, ActorError<SupervisorMessage>> {
+        let (tx, rx) = flume::bounded(1);
+        let msg = SupervisorMessage::State { reply: tx };
+        self.broadcast.send_async(msg).await?;
+
+        rx.recv_async().await.map_err(|e| {
+            let msg = format!("Send cancelled {e:}");
+            tracing::error!(msg);
+            ActorError::ActorError(msg)
+        })
+    }
+
+    pub async fn send(&self, event: T) -> Result<(), ActorError<T>> {
+        tracing::trace!("Sending event from handle to actor");
+        self.sender
+            .send_async(event)
+            .await
+            .map_err(ActorError::from)
+    }
+
+    pub(crate) async fn supervisor_send(
+        &self,
+        msg: SupervisorMessage,
+    ) -> Result<(), ActorError<SupervisorMessage>> {
+        tracing::trace!("Sending supervisor msg to actor");
+        self.broadcast
+            .send_async(msg)
             .await
             .map_err(ActorError::from)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,10 @@
 mod actor;
 mod error;
 pub mod handle;
+mod supervisor;
 
-pub use actor::{Actor, ActorState, Event};
+pub use actor::{Actor, ActorState, Event, SupervisedActor};
 pub use error::ActorError;
+pub use supervisor::{Supervisor, SupervisorHandle, SupervisorMessage};
+
+pub type ActorId = u16;

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -1,0 +1,251 @@
+use std::collections::{HashMap, HashSet};
+
+use crate::{handle::ActorHandle, Actor, ActorError, ActorId, ActorState, Event};
+
+pub type Reply<T> = flume::Sender<T>;
+pub type SupervisorActionReply<T> = Reply<Result<T>>;
+pub type Result<T> = std::result::Result<T, ActorError<SupervisorAction>>;
+
+#[derive(Clone, Debug)]
+pub enum SupervisorMessage {
+    SetId { id: ActorId },
+    Id { reply: Reply<ActorId> },
+    Start,
+    Stop,
+    ClearAll,
+    Shutdown,
+    Backup,
+    State { reply: Reply<ActorState> },
+}
+
+pub struct Supervisor {
+    /// Stores sender end for SupervisorMessages by Actor ID
+    bcast: HashMap<ActorId, flume::Sender<SupervisorMessage>>,
+    /// Used to provide actors with unique IDs
+    ids: HashSet<ActorId>,
+    /// Supervisor can also optionally act as an actor
+    /// but is not required to do so
+    receiver: flume::Receiver<SupervisorAction>,
+}
+
+impl Supervisor {
+    pub fn new(receiver: flume::Receiver<SupervisorAction>) -> Self {
+        let mut ids = HashSet::default();
+        ids.extend((0..ActorId::MAX).collect::<Vec<_>>());
+        Self {
+            bcast: HashMap::default(),
+            ids,
+            receiver,
+        }
+    }
+
+    async fn event_loop(mut self) -> Result<()> {
+        loop {
+            match self.receiver.recv_async().await {
+                Ok(event) => self.process(event).await,
+                Err(e) => {
+                    tracing::warn!("Channel error {e:}");
+                    break;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn process(&mut self, action: SupervisorAction) {
+        tracing::trace!("Processing supervisor action {action:?}");
+        match action {
+            SupervisorAction::NewActorSetup { reply } => {
+                reply.send(self.new_supervisee_setup()).ok();
+            }
+            SupervisorAction::ShutdownAll { reply } => {
+                let keys = self.bcast.keys().copied().collect::<Vec<_>>();
+                for key in keys {
+                    self.shutdown_actor(key)
+                        .await
+                        .map_err(|e| {
+                            tracing::error!("Failed to send shutdown to actor {key} {e:}");
+                        })
+                        .ok();
+                }
+                reply.send(Ok(())).ok();
+            }
+            SupervisorAction::Shutdown { id, reply } => {
+                reply.send(self.shutdown_actor(id).await).ok();
+            }
+            SupervisorAction::ActorState { id, reply } => {
+                reply.send(self.actor_state(id).await).ok();
+            }
+            SupervisorAction::GetCurrentIds { reply } => {
+                reply.send(self.get_current_ids().await).ok();
+            }
+        }
+        tracing::debug!("Processed");
+    }
+
+    pub fn new_supervisee_setup(
+        &mut self,
+    ) -> Result<(
+        flume::Sender<SupervisorMessage>,
+        flume::Receiver<SupervisorMessage>,
+        ActorId,
+    )> {
+        let (tx, rx) = flume::unbounded();
+        // todo this could in theory run out of IDs, should check the set is not empty
+        let id = *self
+            .ids
+            .iter()
+            .next()
+            .ok_or_else(|| ActorError::SystemError("too many actors".to_string()))?;
+
+        self.ids.take(&id);
+        let _ = tx.send(SupervisorMessage::SetId { id });
+        self.bcast.insert(id, tx.clone());
+        Ok((tx, rx, id))
+    }
+
+    pub async fn shutdown_actor(&mut self, id: ActorId) -> Result<()> {
+        tracing::trace!("Supervisor shutting down actor id {id:}");
+        if let Some(sender) = self.bcast.get(&id) {
+            sender
+                .send_async(SupervisorMessage::Shutdown)
+                .await
+                .map_err(|e| {
+                    let msg = format!("Send error {e:?}");
+                    tracing::error!(msg);
+                    ActorError::ActorError(msg)
+                })?;
+            // replace the ID back in the set
+            self.ids.insert(id);
+        }
+        Ok(())
+    }
+
+    async fn actor_state(&mut self, id: ActorId) -> Result<ActorState> {
+        tracing::trace!("Supervisor shutting down actor id {id:}");
+        if let Some(sender) = self.bcast.get(&id) {
+            let (tx, rx) = flume::bounded(1);
+            let msg = SupervisorMessage::State { reply: tx };
+
+            sender.send_async(msg).await.map_err(|e| {
+                let msg = format!("Send error {e:?}");
+                tracing::error!(msg);
+                ActorError::ActorError(msg)
+            })?;
+
+            rx.recv_async().await.map_err(|e| {
+                let msg = format!("Send cancelled {e:}");
+                tracing::error!(msg);
+                ActorError::ActorError(msg)
+            })
+        } else {
+            Err(ActorError::SystemError("No such actor ID".to_string()))
+        }
+    }
+
+    // to be used in methods that monitor current state of all
+    // actors, in order to restart if needed. TODO: configure
+    // heartbeat for actors reporting to supervisor
+    async fn get_current_ids(&mut self) -> Vec<ActorId> {
+        self.bcast.keys().copied().collect::<Vec<_>>()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum SupervisorAction {
+    ShutdownAll {
+        reply: SupervisorActionReply<()>,
+    },
+    Shutdown {
+        id: ActorId,
+        reply: SupervisorActionReply<()>,
+    },
+    NewActorSetup {
+        reply: SupervisorActionReply<(
+            flume::Sender<SupervisorMessage>,
+            flume::Receiver<SupervisorMessage>,
+            ActorId,
+        )>,
+    },
+    GetCurrentIds {
+        reply: Reply<Vec<ActorId>>,
+    },
+    ActorState {
+        id: ActorId,
+        reply: SupervisorActionReply<ActorState>,
+    },
+}
+
+/// Supervisor can be a stand-alone entity or
+/// can be created and run like an un-supervised
+/// actor itself
+#[derive(Clone)]
+pub struct SupervisorHandle {
+    handle: ActorHandle<SupervisorAction>,
+}
+
+impl Event for SupervisorAction {}
+
+impl SupervisorHandle {
+    pub fn new() -> (Supervisor, Self) {
+        // create supervisor
+        let (supervisor, handle) = ActorHandle::new(Supervisor::new);
+
+        (supervisor, Self { handle })
+    }
+
+    pub async fn new_supervisee_setup(
+        &self,
+    ) -> Result<(
+        flume::Sender<SupervisorMessage>,
+        flume::Receiver<SupervisorMessage>,
+        ActorId,
+    )> {
+        let (tx, rx) = flume::bounded(1);
+        let msg = SupervisorAction::NewActorSetup { reply: tx };
+        self.handle.send(msg).await?;
+
+        rx.recv_async().await.map_err(|e| {
+            let msg = format!("Send error {e:?}");
+            tracing::error!(msg);
+            ActorError::ActorError(msg)
+        })?
+    }
+
+    pub async fn shutdown_actor(&self, id: ActorId) -> Result<()> {
+        let (tx, rx) = flume::bounded(1);
+        let msg = SupervisorAction::Shutdown { id, reply: tx };
+        self.handle.send(msg).await?;
+
+        rx.recv_async().await.map_err(|e| {
+            let msg = format!("Send error {e:?}");
+            tracing::error!(msg);
+            ActorError::ActorError(msg)
+        })?
+    }
+
+    pub async fn actor_state(&self, id: ActorId) -> Result<ActorState> {
+        let (tx, rx) = flume::bounded(1);
+        let msg = SupervisorAction::ActorState { id, reply: tx };
+        self.handle.send(msg).await?;
+
+        rx.recv_async().await.map_err(|e| {
+            let msg = format!("Send error {e:?}");
+            tracing::error!(msg);
+            ActorError::ActorError(msg)
+        })?
+    }
+}
+
+#[async_trait::async_trait]
+impl Actor<SupervisorAction> for Supervisor
+where
+    SupervisorAction: Event + Send,
+{
+    type Rx = futures::channel::mpsc::Receiver<SupervisorAction>;
+    type Error = ActorError<SupervisorAction>;
+    type Result = std::result::Result<(), Self::Error>;
+    async fn run(self) -> Self::Result {
+        self.event_loop().await
+    }
+}


### PR DESCRIPTION
Adds a very simple structure for supervising actors (via separate supervision-specific traits) along with an example. Supervisor can run stand-alone, or as an unsupervised actor with supervisor-specific handle if multiple threads need to access the supervisor.